### PR TITLE
MySQLコンテナを削除

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -7,17 +7,3 @@ services:
       - ./api:/api
     environment:
       - WATCHFILES_FORCE_POLLING=true # ホットリロードのための設定
-    depends_on:
-      - mysql
-  mysql:
-    image: mysql:8.0
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_DATABASE: mydb
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-      TZ: 'Asia/Tokyo'
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./mysql:/var/lib/mysql


### PR DESCRIPTION
# やったこと
- mysqlコンテナを削除した

# 結果
```
docker compose up
WARN[0000] Found orphan containers ([server-mysql-1]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.

[+] Running 1/1
 ✔ Container server-api-1  Created                                                               0.0s
Attaching to api-1
api-1  | INFO:     Will watch for changes in these directories: ['/api']
api-1  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
api-1  | INFO:     Started reloader process [10] using StatReload
api-1  | INFO:     Started server process [12]
api-1  | INFO:     Waiting for application startup.
api-1  | INFO:     Application startup complete.
api-1  | INFO:     172.25.0.1:50114 - "GET /socket.io/?EIO=4&transport=polling&t=2khstz08 HTTP/1.1" 200 OK
api-1  | connect  PYy9VqVvY8afDB8TAAAB
api-1  | INFO:     172.25.0.1:50114 - "POST /socket.io/?EIO=4&transport=polling&t=2kht18sn&sid=kNZr41DFQanhiZo1AAAA HTTP/1.1" 200 OK
api-1  | INFO:     ('172.25.0.1', 50130) - "WebSocket /socket.io/?EIO=4&transport=websocket&sid=kNZr41DFQanhiZo1AAAA" [accepted]
api-1  | INFO:     172.25.0.1:50132 - "GET /socket.io/?EIO=4&transport=polling&t=2kht2y0a&sid=kNZr41DFQanhiZo1AAAA HTTP/1.1" 200 OK
```